### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills using GitHub, part of our GitHub Certifications program",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the **GitHub Skills** activity to the extracurricular activities list, addressing the time-sensitive request from issue #6.

## Changes

- Added "GitHub Skills" activity to the activities dictionary in `src/app.py`
- Schedule: Mondays and Wednesdays, 3:30 PM - 4:30 PM
- Max participants: 25
- Description references the GitHub Certifications program

## Related Issue

Closes #6 

Students can now sign up for the GitHub Skills activity that was announced by the principal. This is part of the school's GitHub Certifications program which will help with college applications.